### PR TITLE
Add missing offset for LargeAssetSizeLimit

### DIFF
--- a/psobb_largeassets/dllmain.c
+++ b/psobb_largeassets/dllmain.c
@@ -32,7 +32,8 @@ ULONG listAssetSizeLimit[] = {
   0x005B82AD,
   0x005BB40C,
   0x005E581E,
-  0x007A6573
+  0x007A6573,
+  0x0081A965
 };
 
 static void patch_asset_limits(void) {


### PR DESCRIPTION
It seems the patch used here (and by extension Blue-Burst-Patch-Project) for loading larger assets did not account for loading xvms out of prs files.

Patching this fixes every issue mentioned in this issue. Including replacing the title screen, as both issues stem from the same problem.
https://github.com/anzz1/psobb_patches/issues/6